### PR TITLE
some changes in v3 beta.ahk

### DIFF
--- a/Valorant Triggerbot AHK/v3 beta.ahk
+++ b/Valorant Triggerbot AHK/v3 beta.ahk
@@ -14,6 +14,30 @@ CoordMode, Pixel, Screen
 SoundBeep, 300, 200
 SoundBeep, 400, 200
 
+;HOTKEYS
+key_stay_on	    := 	"F1"	; self explanatory		
+key_hold_mode	:= 	"F2"	; scan will only scan if "key_hold" is pressed
+key_fastclick 	:= 	"F3"	; self explanatory (on/off beep sound only)
+key_burstclick  :=  "F4"    ; self explanatory
+key_off		    := 	"F5"	; self explanatory	
+key_exit	    := 	"F6"    ; self explanatory	
+key_gui_hide	:=	"F7"	; hides gui (graphical user interface)		
+key_hold	    :=	"LALT" 	; key that you hold to scan (example "T") 	
+
+;SETTINGS
+pixel_box	    := 3		    ; Keep between min 3 and max 8		
+pixel_sens	    := 20	        ; higher/lower = more/less color sensitive 		
+pixel_color	    := 0xA145A3     ; yellow="0xFEFE40", purple="0xA145A3" 
+lowerreacttb    := 160          ; lowest delay tb ; for best use 150, 200, for more human 160, 300, and rage 10,11
+upperreacttb    := 300          ; highest delay tb
+lowerspam       := 10           ; lowest delay slow   
+upperspam       := 20           ; highest delay fast
+burstcount      := 3            ; x times
+burstbullettimel:= 20
+burstbullettimeu:= 30
+bursttimingl    := 150
+bursttimingu    := 170
+
 ;DO NOT TOUCH?
 Gui,2:Font,Cdefault,Fixedsys
 Gui,2:Color,Black
@@ -33,16 +57,6 @@ rightbound:= A_ScreenWidth/2+pixel_box
 topbound:= A_ScreenHeight/2-pixel_box
 bottombound:= A_ScreenHeight/2+pixel_box 
 
-;HOTKEYS
-key_stay_on	    := 	"F1"	; self explanatory		
-key_hold_mode	:= 	"F2"	; scan will only scan if "key_hold" is pressed
-key_fastclick 	:= 	"F3"	; self explanatory (on/off beep sound only)
-key_burstclick  :=  "F4"    ; self explanatory
-key_off		    := 	"F5"	; self explanatory	
-key_exit	    := 	"F6"    ; self explanatory	
-key_gui_hide	:=	"F7"	; hides gui (graphical user interface)		
-key_hold	    :=	"LALT" 	; key that you hold to scan (example "T") 	
-
 hotkey, %key_stay_on%, stayon
 hotkey, %key_hold_mode%, holdmode
 hotkey, %key_fastclick%, fastclick
@@ -50,26 +64,14 @@ hotkey, %key_burstclick%, burstclick
 hotkey, %key_off%, offloop
 hotkey, %key_exit%, terminate
 hotkey, %key_gui_hide%, guihide
-
-
-;SETTINGS
-pixel_box	    := 3		    ; Keep between min 3 and max 8		
-pixel_sens	    := 20	        ; higher/lower = more/less color sensitive 		
-pixel_color	    := 0xA145A3     ; yellow="0xFEFE40", purple="0xA145A3" 
-lowerreacttb    := 160          ; lowest delay tb ; for best use 150, 200, for more human 160, 300, and rage 10,11
-upperreacttb    := 300          ; highest delay tb
-lowerspam       := 10           ; lowest delay slow   
-upperspam       := 20           ; highest delay fast
-burstcount      := 3            ; x times
-burstbullettimel:= 20
-burstbullettimeu:= 30
-bursttimingl    := 150
-bursttimingu    := 170
-
-
 return
 start:
 gui,2:submit,nohide
+terminate:
+SoundBeep, 300, 200
+SoundBeep, 200, 200
+Sleep 400
+exitapp
 ;----------------------------
 stayon:
 SoundBeep, 300, 200
@@ -97,7 +99,7 @@ fastclick:
 x := 2
 SoundBeep, 300, 200
 settimer, loop1, off
-settimer, loop2, off
+settimer, loop2, 100
 GuiControl,2: hide,B1
 GuiControl,2: hide,C1
 GuiControl,2: hide,B2
@@ -109,7 +111,7 @@ burstclick:
 x := 3
 SoundBeep, 300, 200
 settimer, loop1, off
-settimer, loop2, off
+settimer, loop2, 100
 GuiControl,2: hide,B1
 GuiControl,2: hide,C1
 GuiControl,2: hide,B2
@@ -137,11 +139,6 @@ GuiControl,2: hide,C2
 GuiControl,2: hide,B3
 GuiControl,2: hide,C3
 return
-terminate:
-SoundBeep, 300, 200
-SoundBeep, 200, 200
-Sleep 400
-exitapp
 ;------------------------
 *~$LButton::
 While GetKeyState("LButton", "P") && !GetKeyState("a") && !GetKeyState("s") && !GetKeyState("d") && !GetKeyState("w") {


### PR DESCRIPTION
1. Reordering and Addition of Comments: The "HOTKEYS" section is moved up in the script.
The "SETTINGS" section is also moved up before the GUI definition and assignment of leftbound, rightbound, topbound, and bottombound.

2. Hotkey Definitions: The hotkey definitions are moved up after the GUI setup and before the start label.

3. GUI Initialization: The Gui,2: Show, x10 y1 w200 h60 command is moved up before the WinSet, TransColor, EEAA99 command.

4. Timers: In the fastclick and burstclick functions, settimer, loop2, 100 is added to restart the loop2 timer instead of turning it off.

5. GuiControl Commands: The GuiControl commands are simplified to hide or show respective elements directly after starting, without additional settimer commands for loop2.